### PR TITLE
Opened up taskDefinitionListRetrieve to default to retrieve all TaskDefinitions.

### DIFF
--- a/controllers/taskApiController.js
+++ b/controllers/taskApiController.js
@@ -25,9 +25,10 @@ exports.taskDefinitionListRetrieve = async (request, response) => {
     success: true,
   };
   try {
-    const params = {
-      taskGroupId,
-    };
+    let params = {};
+    if (taskGroupId && taskGroupId >= 0) {
+      params = { taskGroupId };
+    }
     if (searchText) {
       jsonData.isSearching = true;
       params.OR = [


### PR DESCRIPTION
Opened up taskDefinitionListRetrieve to default to retrieve all TaskDefinitions instead of being limited to only the definitions for one taskGroupId.