### PR TITLE
Check for populateSqlFromCsv.js is done

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -25,6 +25,8 @@ SESSION_EXPIRATION_DAYS=14
 
 SITE_CONTACT_EMAIL=info@wevote.us
 
+PATH_FOR_TEMP_FILES=/tmp
+
 ==============================================================
 
 

--- a/controllers/updateSqlFromCsvController.js
+++ b/controllers/updateSqlFromCsvController.js
@@ -1,0 +1,40 @@
+// Calls script that populates the WeConnectDB from a spreadsheet that has been exported as csv
+// This is a non-destructive update, it will not overwrite existing teams or persons
+
+const fs = require('fs');
+const execSync = require('child_process').execSync;
+const validator = require('validator');
+
+exports.updateDbFromCsv = async (request, response) => {
+  const csvText = request.body.csv;
+  let success = false;
+  let error = '';
+  let outputString = '';
+
+  const isValidLength = validator.isLength(csvText, {
+    min: 800,
+    max: 1000000,
+  }); // one line to ~1000 lines
+
+  if (isValidLength) {
+    const fileName = `${process.env.PATH_FOR_TEMP_FILES}/csv-${Date.now()}.csv`;
+    // Asynchronous file creation and writing
+    try {
+      fs.writeFileSync(fileName, csvText);
+    } catch (err) {
+      console.error('An error occurred in creating a temp csv file:', err);
+      error = err;
+    }
+    outputString = execSync(`node ./node_scripts/populateSqlFromCsv.js ${fileName}`).toString();
+    // console.log(outputString);
+    success = true;
+    console.log('afterWriteFileSync');
+  } else {
+    error = 'incoming csv not within size limits';
+  }
+  return response.json({
+    success,
+    error,
+    outputString,
+  });
+};

--- a/models/personModel.js
+++ b/models/personModel.js
@@ -37,6 +37,10 @@ const PERSON_FIELDS_ACCEPTED = [
 ];
 const PERSON_FIELDS_ACCEPTED_ADMIN = PERSON_FIELDS_ACCEPTED.concat([
   'isAdmin',
+  'isHRAdmin',
+  'isHROfferAdmin',
+  'isHRGeneralist1',
+  'isHRGeneralist2',
   'isHiringManager',
   'isIntern',
   'isTeamLead',
@@ -47,7 +51,7 @@ const PERSON_FIELDS_ACCEPTED_ADMIN = PERSON_FIELDS_ACCEPTED.concat([
 
 const ACCESS_RIGHTS_OPTIONS = [
   'canAddPerson', 'canAddPersonDataAnyone', 'canAddTeam',
-  'canAddTeamMemberAnyTeam', 'canCreateOrgEmailAccount',
+  'canAddTeamMemberAnyTeam', 'canCreateOrgEmailAccount', 'canDoAnythingIsAdmin',
   'canEditPermissionsAnyone', 'canEditPersonAnyone',
   'canEditTeamAnyTeam',
   'canRemoveTeam', 'canRemoveTeamMemberAnyTeam',

--- a/node_scripts/populateSqlFromCsv.js
+++ b/node_scripts/populateSqlFromCsv.js
@@ -31,17 +31,17 @@ const usaDateToIso = (dateString) => {
 
 const createPersonUpdateDict = (row) => {
   const dict = {};
-  let isAuthoritative = true;
+  let isFlagedInCsvAsAuthoritative = true;
   let who = row.Who;
   try {
     // Name
     who = who.replace('\n', '');
     if (who.startsWith('*')) {
-      isAuthoritative = false;
+      isFlagedInCsvAsAuthoritative = false;
       who = who.replace('* ', '');
     }
     const dashedParts = who.split(' - ');
-    const leave = (dashedParts[1] && dashedParts[1].toLowerCase().includes('break')) || false;
+    const leave = (dashedParts[1] && (dashedParts[1].toLowerCase().includes('break') || dashedParts[1].toLowerCase().includes('leave'))) || false;
     const resigned = (dashedParts[1] && dashedParts[1].toLowerCase().includes('resigned')) || false;
     dict.statusResigned = resigned;
     dict.statusActive = !leave && !resigned;
@@ -73,6 +73,10 @@ const createPersonUpdateDict = (row) => {
       dict.emailOfficial = secondary;
       dict.emailPersonal = primary;
     }
+    if (dict.emailPersonal.length === 0) {
+      dict.emailPersonal = dict.emailOfficial;
+    }
+
     dict.dateStarted = usaDateToIso(row['Start date']);
     dict.dateEndDate = usaDateToIso(row['Known End date']);
     dict.emailPersonalAlternate = row['Third email'];
@@ -120,7 +124,7 @@ const createPersonUpdateDict = (row) => {
   } catch (e) {
     console.log('Exception in createPersonUpdateDict: ', e);
   }
-  return { isAuthoritative, dict, who };
+  return { isFlagedInCsvAsAuthoritative, dict, who };
 };
 
 
@@ -146,7 +150,6 @@ function isTeamATeamName (str) {
 }
 
 const processCsv = async (file) => {
-  const authoritativePersons = [];
   let teamFromSql;
   let teamsAdded = 0;
   let peopleAdded = 0;
@@ -174,35 +177,38 @@ const processCsv = async (file) => {
           if (!teamFromSql) {
             teamFromSql = await createTeam(teamDict);
             teamsAdded += 1;
+            console.log('------------------- Team Created ---------------------', row.Team);
           }
-          console.log('------------------- Team Created ---------------------', row.Team);
         } else {
           // Person save or update (or don't save person if person exists and this row is non-authoritative)
-          const { isAuthoritative, dict: personUpdateDict, who } = createPersonUpdateDict(row);
+          const { isFlagedInCsvAsAuthoritative, dict: personUpdateDict, who } = createPersonUpdateDict(row);
           let person = await findPersonListByParams({ emailPersonal: personUpdateDict.emailPersonal }, true);
           person = (person.length > 0) ? person[0] : undefined;
+          const isNonAuthoritativeInSQL = person?.nonAuthoritativeImport || false;
 
           console.log(`ROW ${personUpdateDict.lastName} ${personUpdateDict.emailPersonal} ${personUpdateDict.emailOfficial}`);
           if (personUpdateDict.emailPersonal.length === 0 && personUpdateDict.emailOfficial.length === 0) {
             console.log(`ROW SKIPPED: No valid personal or official ('2nd Email' or 'Primary Email') in row #${i}: ${who}`);
           }
-          if (isAuthoritative && !person) {
+          if (isFlagedInCsvAsAuthoritative && !person) {
             // First instance of a person in the sheet, is authoritative, and does not exist in SQL
             console.log(`Authoritative Person creates new person: '${who}'  '${personUpdateDict.firstName}'  '${personUpdateDict.lastName}'  '${personUpdateDict.emailPersonal}'`);
+            personUpdateDict.nonAuthoritativeImport = false;   // nonAuthoritativeImport Already defaults as false, but here for self-documentation
             person = await createPerson(personUpdateDict);
-            authoritativePersons.push(person.emailPersonal);
+            // authoritativePersons.push(person.emailPersonal);
             peopleAdded += 1;
-          }  else if (isAuthoritative && person) {
+          }  else if (isFlagedInCsvAsAuthoritative && person && isNonAuthoritativeInSQL) {
             // If the first instance of a person in the sheet was non-authoritative (starts with a  '*'), we saved them so that
-            // we could add them to a team.  This instance is authoritative, so overwrite the person with this authoritative row
+            // we could add them to a team.  This instance is authoritative, so overwrite the non-authoritative person with this authoritative row
             console.log(`Authoritative Person overwrites non-authoritative: '${who}'  '${personUpdateDict.firstName}'  '${personUpdateDict.lastName}'  '${personUpdateDict.emailPersonal}'`);
             personUpdateDict.id = person.id;
+            personUpdateDict.nonAuthoritativeImport = false;
             person = await savePerson(personUpdateDict);
-            authoritativePersons.push(person.emailPersonal);
             peopleAdded += 1;
-          } else if (!isAuthoritative && !person && !authoritativePersons.includes(personUpdateDict.emailPersonal)) {
+          } else if (!isFlagedInCsvAsAuthoritative && !person) {
             // Save a non-authoritative person, since that person does not exist in SQL, and we need to add them to a team
             console.log(`Non-authoritative Person created: '${who}'  '${personUpdateDict.firstName}'  '${personUpdateDict.lastName}'  '${personUpdateDict.emailPersonal}'`);
+            personUpdateDict.nonAuthoritativeImport = true;   // This case is the reason we need this field
             person = await createPerson(personUpdateDict);
           } else {
             console.log(`Non-authoritative Person NOT saved: '${who}'  '${personUpdateDict.firstName}'  '${personUpdateDict.lastName}'  '${personUpdateDict.emailPersonal}'`);
@@ -220,7 +226,7 @@ const processCsv = async (file) => {
           // console.log(teamMember);
         }
       }
-      console.log(`\n\nDONE -------- teams added: ${teamsAdded} ---- people added (or overwritten): ${peopleAdded}`);
+      console.log(`\n\nDONE ---------------- teams added: ${teamsAdded} ---- people added: ${peopleAdded}`);
     });
 };
 

--- a/prisma/schema/person.prisma
+++ b/prisma/schema/person.prisma
@@ -84,6 +84,9 @@ model Person {
   /// Person notified us they have resigned
   statusResigned            Boolean?
   importNote                String?
+  // nonAuthoritativeImport === true, means that while importing from csv, so that we can build the team while proceeding down the sheet
+  // knowing that we will replace them with the authoritative copy when we encounter them.  This is in the DB in case the import crashes and we lose track
+  nonAuthoritativeImport    Boolean   @default(false)
 
   QuestionAnswer QuestionAnswer[]
   TeamMember     TeamMember[]

--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -3,6 +3,7 @@ const personApiController = require('../controllers/personApiController');
 const questionnaireApiController = require('../controllers/questionnaireApiController');
 const taskApiController = require('../controllers/taskApiController');
 const teamApiController = require('../controllers/teamApiController');
+const { updateDbFromCsv } = require('../controllers/updateSqlFromCsvController');
 
 /**
  * WeConnect API routes.
@@ -34,6 +35,7 @@ module.exports = function setupWeConnectRoutes (weconnectServer) {
   weconnectServer.get('/apis/v1/team-retrieve', teamApiController.teamRetrieve);
 
   weconnectServer.post('/apis/v1/get-auth', personApiController.getAuth);
+  weconnectServer.post('/apis/v1/update-db-from-csv', updateDbFromCsv);
   weconnectServer.post('/apis/v1/login', personApiController.login);
   weconnectServer.post('/apis/v1/logout', personApiController.logout);
   weconnectServer.post('/apis/v1/save-password', personApiController.savePassword);

--- a/weconnect-server.js
+++ b/weconnect-server.js
@@ -64,7 +64,8 @@ const corsConfig = {
 };
 weconnectServer.use(cors(corsConfig));
 weconnectServer.use(logger('dev'));
-weconnectServer.use(bodyParser.json());
+// weconnectServer.use(express.bodyParser({limit: '10mb'}));
+weconnectServer.use(bodyParser.json({limit: '10mb'}));
 weconnectServer.use(bodyParser.urlencoded({ extended: true }));
 weconnectServer.use(limiter);
 weconnectServer.use(cookieParser());
@@ -127,8 +128,6 @@ weconnectServer.use((req, res, next) => {
   next();
 });
 
-
-
 // After successful login, redirect back to the intended page
 weconnectServer.use((req, res, next) => {
   if (!req.user &&
@@ -150,8 +149,6 @@ weconnectServer.use((req, res, next) => {
   res.locals.login = req.user;   // TODO user seems to be always undefined, so probably useless
   next();
 });
-
-
 
 weconnectServer.use('/', express.static(path.join(__dirname, 'public'), { maxAge: 31557600000 }));
 weconnectServer.use('/js/lib', express.static(path.join(__dirname, 'node_modules/chart.js/dist'), { maxAge: 31557600000 }));


### PR DESCRIPTION
This script can still be run from the command line, but also now is run by a button at the bottom of the client system-settings page
Added a new environment variable:  PATH_FOR_TEMP_FILES=/tmp
Added a new const ACCESS_RIGHTS_OPTIONS   'canDoAnythingIsAdmin' so that only admins can see this new button.
Requires a 'prisma migrate dev'

 