### PR TITLE
Upgraded generateTaskStatusListForAllPeople so we can configure TaskGroups to be used when a person is on a specific team. Now able to attach more than one team to a TaskGroup. We can now add/update or delete TaskGroupTeamLink. populateSqlFromCsv can now set these status' from imported spreadsheet: statusEmailCreated, statusOfferDecisionNeeded, statusOfferLetterCreated

### DIFF
--- a/controllers/taskApiController.js
+++ b/controllers/taskApiController.js
@@ -1,10 +1,10 @@
 // weconnect-server/controllers/taskApiController.js
 const { retrieveTaskStatusListByPersonIdList } =  require('./taskController');
-const { createTaskDefinition, createTaskGroup,
-  findTaskDefinitionListByParams, findTaskGroupById, findTaskGroupListByParams,
+const { createTaskDefinition, createTaskGroup, deleteOneTaskGroupTeamLink,
+  findTaskDefinitionListByParams, findTaskGroupById, findTaskGroupTeamLinkListByParams, findTaskGroupListByParams,
   TASK_DEFINITION_FIELDS_ACCEPTED, TASK_FIELDS_ACCEPTED_DICT, TASK_GROUP_FIELDS_ACCEPTED,
   removeProtectedFieldsFromTask, removeProtectedFieldsFromTaskDefinition, removeProtectedFieldsFromTaskGroup,
-  saveTaskDefinition, saveTaskGroup, updateOrCreateTask } = require('../models/taskModel');
+  saveTaskDefinition, saveTaskGroup, updateOrCreateTask, updateOrCreateTaskGroupTeamLink } = require('../models/taskModel');
 const { extractVariablesToChangeFromIncomingParams } = require('./dataTransformationUtils');
 const { convertToInteger } = require('../utils/convertToInteger');
 
@@ -43,6 +43,34 @@ exports.taskDefinitionListRetrieve = async (request, response) => {
       jsonData.status += 'TASK_DEFINITION_LIST_FOUND ';
     } else {
       jsonData.status += 'TASK_DEFINITION_LIST_NOT_FOUND ';
+    }
+  } catch (err) {
+    jsonData.status += err.message;
+    jsonData.success = false;
+  }
+  response.json(jsonData);
+};
+
+/**
+ * GET /api/v1/task-group-team-link-list-retrieve
+ * Retrieve a list of taskGroupTeamLink entries.
+ */
+exports.taskGroupTeamLinkListRetrieve = async (request, response) => {
+  const jsonData = {
+    taskGroupTeamLinkList: [],
+    status: '',
+    success: true,
+  };
+  try {
+    const params = {};
+    const taskGroupTeamLinkList = await findTaskGroupTeamLinkListByParams(params);
+    jsonData.success = true;
+    // console.log('== AFTER findTaskGroupTeamLinkListByParams taskGroupTeamLinkList:', taskGroupTeamLinkList);
+    if (taskGroupTeamLinkList) {
+      jsonData.taskGroupTeamLinkList = taskGroupTeamLinkList;
+      jsonData.status += 'TASK_GROUP_TEAM_LINK_LIST_FOUND ';
+    } else {
+      jsonData.status += 'TASK_GROUP_TEAM_LINK_LIST_NOT_FOUND ';
     }
   } catch (err) {
     jsonData.status += err.message;
@@ -355,6 +383,101 @@ exports.taskDefinitionSave = async (request, response) => {
     }
   } catch (err) {
     console.error('Error while saving taskDefinition:', err);
+    jsonData.status += err.message;
+    jsonData.success = false;
+  }
+
+  response.json(jsonData);
+};
+
+/**
+ * GET /api/v1/task-group-team-link-delete
+ */
+exports.taskGroupTeamLinkDelete = async (request, response) => {
+  const parsedUrl = new URL(request.url, `${process.env.BASE_URL}`);
+  const queryParams = new URLSearchParams(parsedUrl.search);
+  const taskGroupId = convertToInteger(queryParams.get('taskGroupId'));
+  const teamId = convertToInteger(queryParams.get('teamId'));
+
+  // Set up the default JSON response.
+  const jsonData = {
+    taskGroupId,
+    taskGroupTeamLinkDeleted: false,
+    teamId,
+    status: '',
+    success: true,
+    updateErrors: [],
+  };
+
+  try {
+    if (parseInt(teamId) >= 0) {
+      jsonData.status += 'TASK_GROUP_TEAM_LINK_TO_BE_DELETED ';
+      await deleteOneTaskGroupTeamLink(taskGroupId, teamId);
+      // console.log('Deleted TaskGroupTeamLink taskGroupId:', taskGroupId, ', teamId:', teamId);
+      jsonData.taskGroupTeamLinkDeleted = true;
+      jsonData.status += 'TASK_GROUP_TEAM_LINK_DELETED ';
+    }
+  } catch (err) {
+    console.error('Error while deleting TaskGroupTeamLink:', err);
+    jsonData.status += err.message;
+    jsonData.success = false;
+  }
+
+  response.json(jsonData);
+};
+
+/**
+ * GET /api/v1/task-group-team-link-save
+ *
+ */
+exports.taskGroupTeamLinkSave = async (request, response) => {
+  const parsedUrl = new URL(request.url, `${process.env.BASE_URL}`);
+  const queryParams = new URLSearchParams(parsedUrl.search);
+  const taskGroupId = convertToInteger(queryParams.get('taskGroupId'));
+  const teamId = convertToInteger(queryParams.get('teamId'));
+  // Set up the default JSON response.
+  const jsonData = {
+    taskCreated: false,
+    teamId: -1,
+    taskGroupId: -1,
+    taskUpdated: false,
+    status: '',
+    success: true,
+    updateErrors: [],
+  };
+  try {
+    jsonData.taskGroupId = taskGroupId;
+    jsonData.teamId = teamId;
+    jsonData.success = true;
+  } catch (err) {
+    jsonData.status += err.message;
+    jsonData.success = false;
+  }
+
+  try {
+    let requiredFieldsExist = true;
+    if (teamId < 0) {
+      jsonData.status += 'teamId_MISSING ';
+      requiredFieldsExist = false;
+    }
+    if (taskGroupId < 0) {
+      jsonData.status += 'WARNING_taskGroupId_MISSING ';
+    }
+
+    if (requiredFieldsExist) {
+      const taskGroupTeamLink = await updateOrCreateTaskGroupTeamLink(taskGroupId, teamId);
+      jsonData.taskCreated = true;
+      jsonData.taskGroupId = taskGroupTeamLink.taskGroupId;
+      jsonData.teamId = taskGroupTeamLink.teamId;
+      jsonData.status += 'TASK_GROUP_TEAM_LINK_UPDATED_OR_CREATED ';
+      const taskKeys = Object.keys(taskGroupTeamLink);
+      const taskValues = Object.values(taskGroupTeamLink);
+      for (let i = 0; i < taskKeys.length; i++) {
+        jsonData[taskKeys[i]] = taskValues[i];
+      }
+    }
+  } catch (err) {
+    console.error('Error while saving taskGroupTeamLink:', err);
     jsonData.status += err.message;
     jsonData.success = false;
   }

--- a/controllers/taskController.js
+++ b/controllers/taskController.js
@@ -2,7 +2,7 @@
 const { findQuestionAnswerListByParams } = require('../models/questionnaireModel');
 const {
   createTask,
-  findTaskDefinitionListByParams, findTaskDependencyListByParams, findTaskGroupListByIdList,
+  findTaskDefinitionListByParams, findTaskDependencyListByParams, findTaskGroupTeamLinkListByParams, findTaskGroupListByIdList,
   findTaskGroupListByParams, findTaskListByParams,
   // TASK_DEFINITION_FIELDS_ACCEPTED,
 } = require('../models/taskModel');
@@ -103,27 +103,16 @@ exports.generateTaskStatusListForAllPeople = async () => {
   // Assemble which teams are associated with each task group when taskGroupIsForTeam is true
   const taskGroupTeamIdLists = {}; // key = taskGroupId, value = [teamId1, teamId2,...]
   try {
-    // TODO: Create table that supports more than one team per task group
-    // const paramsTaskGroupTeam = {};
-    // const taskGroupTeamList = await findTaskGroupTeamListByParams(paramsTaskGroupTeam);
-    // for (let i = 0; i < taskGroupTeamList.length; i++) {
-    //   // If taskGroupId is not found in dict, we create it
-    //   if (!taskGroupTeamIdLists[taskGroupTeamList[i].taskGroupId]) {
-    //     taskGroupTeamIdLists[taskGroupTeamList[i].taskGroupId] = [];
-    //   }
-    //   taskGroupTeamIdLists[taskList[i].taskGroupId].push(taskGroupTeamList[i].taskGroupTeamId);
-    // }
-    // Temp
-    for (let i = 0; i < taskGroupList.length; i++) {
-      if (taskGroupList[i].taskGroupTeamId && taskGroupList[i].taskGroupTeamId > 0) {
-        // If task is not found in dict, we create it
-        if (!taskGroupTeamIdLists[taskGroupList[i].id]) {
-          taskGroupTeamIdLists[taskGroupList[i].id] = [];
-        }
-        taskGroupTeamIdLists[taskGroupList[i].id].push(taskGroupList[i].taskGroupTeamId);
+    const paramsTaskGroupTeamLink = {};
+    const taskGroupTeamLinkList = await findTaskGroupTeamLinkListByParams(paramsTaskGroupTeamLink);
+    // console.log('generateTaskStatusListForAllPeople taskGroupTeamLinkList:', taskGroupTeamLinkList);
+    for (let i = 0; i < taskGroupTeamLinkList.length; i++) {
+      // If taskGroupId is not found in dict, we create it
+      if (!taskGroupTeamIdLists[taskGroupTeamLinkList[i].taskGroupId]) {
+        taskGroupTeamIdLists[taskGroupTeamLinkList[i].taskGroupId] = [];
       }
+      taskGroupTeamIdLists[taskGroupTeamLinkList[i].taskGroupId].push(taskGroupTeamLinkList[i].teamId);
     }
-    // console.log('generateTaskStatusListForAllPeople taskGroupDict:', taskGroupDict);
     // console.log('generateTaskStatusListForAllPeople taskGroupTeamIdLists:', taskGroupTeamIdLists);
   } catch (err) {
     status += `Error while fetching taskGroupIsForTeam: ${err.message} `;
@@ -145,10 +134,10 @@ exports.generateTaskStatusListForAllPeople = async () => {
   // Add params that look for values in person records that imply tasks needs to be generated?
   const paramsPersonList = { statusActive: true };
   const personList = await findPersonListByParams(paramsPersonList);
-  const personDict = personList.reduce((acc, person) => {
-    acc[person.id] = person;
-    return acc;
-  }, {});
+  // const personDict = personList.reduce((acc, person) => {
+  //   acc[person.id] = person;
+  //   return acc;
+  // }, {});
   // console.log('personDict[1]:', personDict[1]);
   let taskListForPerson = [];
   for (let i = 0; i < personList.length; i++) {

--- a/models/personModel.js
+++ b/models/personModel.js
@@ -59,6 +59,7 @@ const PERSON_FIELDS_ACCEPTED_ADMIN = {
   phoneNumber: 'STRING',
   statusActive: 'BOOLEAN',
   statusAvailableForSpecialProjects: 'BOOLEAN',
+  statusEmailCreated: 'BOOLEAN',
   statusOfferApproved: 'BOOLEAN',
   statusOfferDecisionNeeded: 'BOOLEAN',
   statusOfferLetterSigned: 'BOOLEAN',

--- a/models/taskModel.js
+++ b/models/taskModel.js
@@ -57,7 +57,6 @@ const TASK_GROUP_FIELDS_ACCEPTED = {
   taskGroupName: 'STRING',
   taskGroupDescription: 'STRING',
   taskGroupIsForTeam: 'BOOLEAN',
-  taskGroupTeamId: 'INTEGER',
 };
 
 function removeProtectedFieldsFromTask (task) {
@@ -214,6 +213,13 @@ async function findTaskGroupListByIdList (idList, includeAllData = false) {
   return modifiedTaskGroupList;
 }
 
+async function findTaskGroupTeamLinkListByParams (params = {}) {
+  const taskGroupTeamLinkList = await prisma.taskGroupTeamLink.findMany({
+    where: params,
+  });
+  return taskGroupTeamLinkList;
+}
+
 async function findTaskGroupListByParams (params = {}, includeAllData = false) {
   const taskGroupList = await prisma.taskGroup.findMany({
     where: params,
@@ -254,6 +260,17 @@ async function deleteOneTaskGroup (id) {
   await prisma.taskGroup.delete({
     where: {
       id,
+    },
+  });
+}
+
+async function deleteOneTaskGroupTeamLink (taskGroupId, teamId) {
+  await prisma.taskGroupTeamLink.delete({
+    where: {
+      taskGroupIdTeamId: {
+        taskGroupId,
+        teamId,
+      },
     },
   });
 }
@@ -306,6 +323,21 @@ async function saveTaskGroup (taskGroup) {
   return updateTaskGroup;
 }
 
+async function saveTaskGroupTeamLink (taskGroupTeamLink) {
+  // console.log('saveTaskGroupTeamLink taskGroupTeamLink:', taskGroupTeamLink);
+  const updateTaskGroupTeamLink = await prisma.taskGroupTeamLink.update({
+    where: {
+      taskGroupIdTeamId: {
+        taskGroupId: taskGroupTeamLink.taskGroupId,
+        teamId: taskGroupTeamLink.teamId,
+      },
+    },
+    data: taskGroupTeamLink,
+  });
+  // console.log(updateTaskGroupTeamLink);
+  return updateTaskGroupTeamLink;
+}
+
 async function createTask (updateDict) {
   const task = await prisma.task.create({ data: updateDict });
   return task;
@@ -329,6 +361,12 @@ async function createTaskGroup (updateDict) {
   return taskGroup;
 }
 
+async function createTaskGroupTeamLink (updateDict) {
+  // eslint-disable-next-line prefer-object-spread
+  const taskGroupTeamLink = await prisma.taskGroupTeamLink.create({ data: updateDict });
+  return taskGroupTeamLink;
+}
+
 function updateOrCreateTask (personId, taskDefinitionId, taskGroupId, updateDict) {
   // eslint-disable-next-line prefer-object-spread
   const createDict = Object.assign({}, { personId, taskDefinitionId, taskGroupId }, updateDict);
@@ -350,25 +388,45 @@ function updateOrCreateTask (personId, taskDefinitionId, taskGroupId, updateDict
   }
 }
 
+function updateOrCreateTaskGroupTeamLink (taskGroupId, teamId) {
+  // eslint-disable-next-line prefer-object-spread
+  const createDict = Object.assign({}, { taskGroupId, teamId });
+  try {
+    const upResult =  prisma.taskGroupTeamLink.upsert({
+      where: {
+        taskGroupIdTeamId: {
+          taskGroupId,
+          teamId,
+        },
+      },
+      update: { ...createDict },
+      create: { ...createDict },
+    });
+    return upResult;
+  } catch (err) {
+    console.log('updateOrCreateTaskGroupTeamLink: ERROR ', err);
+    return null;
+  }
+}
+
 module.exports = {
   createTask,
   createTaskDefinition,
   createTaskDependency,
   createTaskGroup,
+  createTaskGroupTeamLink,
   deleteOneTaskGroup,
+  deleteOneTaskGroupTeamLink,
   extractTaskGroupVariablesToChange,
   findTaskDefinitionListByParams,
   findTaskDependencyListByParams,
   findTaskListByIdList,
   findTaskListByParams,
   findTaskGroupById,
+  findTaskGroupTeamLinkListByParams,
   findTaskGroupListByIdList,
   findTaskGroupListByParams,
   findOneTaskGroup,
-  TASK_DEFINITION_FIELDS_ACCEPTED,
-  TASK_FIELDS_ACCEPTED,
-  TASK_FIELDS_ACCEPTED_DICT,
-  TASK_GROUP_FIELDS_ACCEPTED,
   removeProtectedFieldsFromTask,
   removeProtectedFieldsFromTaskDefinition,
   removeProtectedFieldsFromTaskDependency,
@@ -377,5 +435,11 @@ module.exports = {
   saveTaskDefinition,
   saveTaskDependency,
   saveTaskGroup,
+  saveTaskGroupTeamLink,
+  TASK_DEFINITION_FIELDS_ACCEPTED,
+  TASK_FIELDS_ACCEPTED,
+  TASK_FIELDS_ACCEPTED_DICT,
+  TASK_GROUP_FIELDS_ACCEPTED,
   updateOrCreateTask,
+  updateOrCreateTaskGroupTeamLink,
 }; // Export the functions

--- a/node_scripts/populateSqlFromCsv.js
+++ b/node_scripts/populateSqlFromCsv.js
@@ -59,8 +59,11 @@ const createPersonUpdateDict = (row) => {
     dict.lastName = nameParts[1] + (nameParts.length === 3 ? (` ${nameParts[2].trim()}`) : '');   // Jill Depti Bargam
     dict.importNote = dashedParts[1] || '';
 
+    dict.statusEmailCreated = row['*We Vote Email Created\n(link)'].trim() === 'Done';
+    dict.statusOfferApproved = row['Team meeting OR 2nd interview'].trim() === 'Done';
+    dict.statusOfferDecisionNeeded = false; // We are setting this to false for all imported people
+    dict.statusOfferLetterCreated = row['Create Offer Letter'].trim() === 'Done';
     dict.statusOfferLetterSigned = row['Offer Letter Status (before purple line)'].trim() === 'Signed';
-    dict.statusOfferApproved = dict.statusOfferLetterSigned;
     // dict.???  = row['Team On- boarding Status'].trim() === 'Complete';
     dict.jazzHrUrl = row['Jazz Link'];
     dict.location = row.Location;
@@ -95,8 +98,8 @@ const createPersonUpdateDict = (row) => {
     Not in db
       "Attended Intro to We Vote":  "IDE installed? (DM)":  "Eng Pair Scheduled (DM)":
       "Team meeting OR 2nd interview": "Confirmation questions sent?": "Invite to Slack":
-      "Answers received": "*We Vote Email Created\n(link)": "Email Credentials sent via Slack":
-      "JazzHR New WeVote Email Message": "*Offer Letter Created": "Create Offer Letter":
+      "Answers received": "Email Credentials sent via Slack":
+      "JazzHR New WeVote Email Message": "*Offer Letter Created":
       "Offer Letter Signed by Dale": "Offer Letter Signed by Volunteer": "Welcome to the team!":
       "Access to Google Drive": "Update status in JazzHR": "Slack Profile\nReminder":
       "Small Team Slack": "Large Team Slack": "Calendar Event (Sephra / Dale)":
@@ -139,8 +142,10 @@ const args = process.argv.slice(2);
 const headerStr = 'Team,' +
   'Who,D1,D2,D3,D4,D5,Offer Letter Status (before purple line),Team On- boarding Status,Jazz Link,Location,State,*Title / Volunteering Love,c3/ c4,Primary Email,2nd Email,Start date,' +
   'Known End date,Active,Available for Special Projects,' +
-  'Third email,Birthday Month / Day,LinkedIn,Hours per week,Hours spent (Active),How long at We Vote?,,End Date in Past,Is Active,For Active Sum,,Attended Intro to We Vote,IDE installed? (DM),Eng Pair Scheduled (DM),Team meeting OR 2nd interview,Confirmation questions sent?,Invite to Slack,Answers received,"*We Vote Email Created\n' +
-  '(link)",Email Credentials sent via Slack,"JazzHR ""New WeVote Email"" Message",*Offer Letter Created,Create Offer Letter,Offer Letter Signed by Dale,Offer Letter Signed by Volunteer,"""Welcome to the team!""",Access to Google Drive,Update status in JazzHR,"Slack Profile\n' +
+  'Third email,Birthday Month / Day,LinkedIn,Hours per week,Hours spent (Active),How long at We Vote?,,End Date in Past,Is Active,For Active Sum,,Attended Intro to We Vote,IDE installed? (DM),Eng Pair Scheduled (DM),Team meeting OR 2nd interview,Confirmation questions sent?,Invite to Slack,Answers received,' +
+  '"*We Vote Email Created\n(link)",' +
+  'Email Credentials sent via Slack,"JazzHR ""New WeVote Email"" Message",*Offer Letter Created,' +
+  'Create Offer Letter,Offer Letter Signed by Dale,Offer Letter Signed by Volunteer,"""Welcome to the team!""",Access to Google Drive,Update status in JazzHR,"Slack Profile\n' +
   'Reminder",,Small Team Slack,Large Team Slack,Calendar Event (Sephra / Dale),Listserv (wevote email) (Meli),,Signed PDF in folder? (Meli),We Vote email signature,Public Intranet Edit Access,Private Intranet Edit Access,Add to Staff History,"Com- munica- tion\n' +
   'Part 1",Part 2,Part 3,Part 4,Part 5,* Added to We Vote LinkedIn?,Birthday fundraiser reminders (NA),,"JazzHR ""Getting Started w/ Community Outreach""",Community Outreach Google Drive,Marketing Google Drive,Design Google Drive,Figma Read Only (Dale),Access to Canva (Sephra),Access to Hubspot,,"JazzHR ""Getting Started with Product Design""",Marketing Google Drive,Design Google Drive,"Figma\n' +
   '(Dale)",Access to Canva (Sephra),Access to Jira,Pageflows,Access to OpenReplay,,"JazzHR ""Getting Started w/ Marketing""",Marketing Google Drive,Strategy Google Drive link,Design Google Drive,Videos & Photos,Access to Jira,Access to Canva (Sephra),Mailchimp (news- letter team),,Hootsuite Password Google Doc,X.com,TikTok Pass Google Doc,Facebook/Insta,BlueSky,LinkedIn Access,,"JazzHR ""Getting Started w/ Marketing Analytics""",Marketing Google Drive,Access to Jira,,Access to API Server (Optional),Access to OpenReplay,Google Analytics,Google Tag Manager,Google Ads (c3 &c4),Google Search Console,New Relic,,"JazzHR ""Getting Started w/ Engineering""",Github Team,"Access to Jira\n' +

--- a/prisma/schema/task.prisma
+++ b/prisma/schema/task.prisma
@@ -97,5 +97,10 @@ model TaskGroup {
   taskGroupTeamId               Int      @default(-1)
 }
 
-/// This team wants this TaskGroup completed for team members
-// TaskGroupLinkToTeam
+/// Assign this TaskGroup to people who are members of this team
+model TaskGroupTeamLink {
+  taskGroupId Int
+  teamId      Int @default(-1)
+
+  @@id(name: "taskGroupIdTeamId", [taskGroupId, teamId])
+}

--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -27,6 +27,9 @@ module.exports = function setupWeConnectRoutes (weconnectServer) {
   weconnectServer.get('/apis/v1/remove-person-from-team', teamApiController.removePersonFromTeam);
   weconnectServer.get('/apis/v1/task-definition-list-retrieve', taskApiController.taskDefinitionListRetrieve);
   weconnectServer.get('/apis/v1/task-definition-save', taskApiController.taskDefinitionSave);
+  weconnectServer.get('/apis/v1/task-group-team-link-delete', taskApiController.taskGroupTeamLinkDelete);
+  weconnectServer.get('/apis/v1/task-group-team-link-list-retrieve', taskApiController.taskGroupTeamLinkListRetrieve);
+  weconnectServer.get('/apis/v1/task-group-team-link-save', taskApiController.taskGroupTeamLinkSave);
   weconnectServer.get('/apis/v1/task-group-list-retrieve', taskApiController.taskGroupListRetrieve);
   weconnectServer.get('/apis/v1/task-group-save', taskApiController.taskGroupSave);
   weconnectServer.get('/apis/v1/task-save', taskApiController.taskSave);


### PR DESCRIPTION
Upgraded generateTaskStatusListForAllPeople so we can configure TaskGroups to be used when a person is on a specific team. Now able to attach more than one team to a TaskGroup. We can now add/update or delete TaskGroupTeamLink. populateSqlFromCsv can now set these status' from imported spreadsheet: statusEmailCreated, statusOfferDecisionNeeded, statusOfferLetterCreated